### PR TITLE
Update cop names

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,10 +1,10 @@
 Layout/AccessModifierIndentation:
   Enabled: false
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 
 # Layout/AlignParameters
@@ -88,16 +88,16 @@ Layout/ExtraSpacing:
 # Layout/FirstMethodArgumentLineBreak
 # Layout/FirstMethodParameterLineBreak
 
+Layout/AssignmentIndentation:
+  Enabled: false
+
+Layout/FirstArrayElementIndentation:
+  Enabled: false
+
+Layout/FirstHashElementIndentation:
+  Enabled: false
+
 Layout/FirstParameterIndentation:
-  Enabled: false
-
-Layout/IndentArray:
-  Enabled: false
-
-Layout/IndentAssignment:
-  Enabled: false
-
-Layout/IndentHash:
   Enabled: false
 
 # Layout/IndentHeredoc
@@ -211,7 +211,7 @@ Layout/SpaceInsideStringInterpolation:
 Layout/Tab:
   Enabled: false
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: false
 
 Layout/TrailingWhitespace:


### PR DESCRIPTION
I got these errors when trying to use this gem:

```
Error: The `Layout/AlignArray` cop has been renamed to `Layout/ArrayAlignment`.
(obsolete configuration found in /usr/local/lib/ruby/gems/2.7.0/gems/rubocop-config-rufo-0.1.0/rubocop.yml, please update it)
The `Layout/AlignHash` cop has been renamed to `Layout/HashAlignment`.
(obsolete configuration found in /usr/local/lib/ruby/gems/2.7.0/gems/rubocop-config-rufo-0.1.0/rubocop.yml, please update it)
The `Layout/IndentArray` cop has been renamed to `Layout/FirstArrayElementIndentation`.
(obsolete configuration found in /usr/local/lib/ruby/gems/2.7.0/gems/rubocop-config-rufo-0.1.0/rubocop.yml, please update it)
The `Layout/IndentAssignment` cop has been renamed to `Layout/AssignmentIndentation`.
(obsolete configuration found in /usr/local/lib/ruby/gems/2.7.0/gems/rubocop-config-rufo-0.1.0/rubocop.yml, please update it)
The `Layout/IndentHash` cop has been renamed to `Layout/FirstHashElementIndentation`.
(obsolete configuration found in /usr/local/lib/ruby/gems/2.7.0/gems/rubocop-config-rufo-0.1.0/rubocop.yml, please update it)
The `Layout/TrailingBlankLines` cop has been renamed to `Layout/TrailingEmptyLines`.
(obsolete configuration found in /usr/local/lib/ruby/gems/2.7.0/gems/rubocop-config-rufo-0.1.0/rubocop.yml, please update it)
```